### PR TITLE
QuickFix for over-decrementing piece count.

### DIFF
--- a/src/model/Board.java
+++ b/src/model/Board.java
@@ -181,6 +181,14 @@ public class Board {
         return result;
     }
 
+    private void incrementPieceCount(int position) {
+        if (this.getPiece(position).isWhite()) {
+            this.numberOfWhitePieces++;
+        } else if (this.getPiece(position).isBlack()) {
+            this.numberOfBlackPieces++;
+        }
+    }
+
     public boolean isEndState() {
         return (this.numberOfBlackPieces == 0 || this.numberOfWhitePieces == 0);
     }
@@ -210,6 +218,7 @@ public class Board {
 
     public void setOccupyingPiece(int position, PieceInterface pieceToSet) {
         this.getSquare(position).setOccupyingPiece(pieceToSet);
+        this.incrementPieceCount(position);
     }
 
 }

--- a/src/model/Board.java
+++ b/src/model/Board.java
@@ -26,8 +26,8 @@ public class Board {
     }
 
     public Board(List<Integer> blackPositions, List<Integer> whitePositions) {
-        this.numberOfBlackPieces = blackPositions.size();
-        this.numberOfWhitePieces = whitePositions.size();
+        this.numberOfBlackPieces = 0;
+        this.numberOfWhitePieces = 0;
         this.gameState = new ArrayList<Square>(32);
 
         for (int position = 1; position <= 32; position++) {


### PR DESCRIPTION
Fix: pickUpPiece made a call to removePiece which decrements board piece color count variables. However if the piece was put back, i.e. setOccupiyingPiece was called, there was no corresponding increment of that piece color count.